### PR TITLE
add local storage service

### DIFF
--- a/packages/client/src/service/store/storage.ts
+++ b/packages/client/src/service/store/storage.ts
@@ -1,0 +1,39 @@
+interface itemWrap {
+  object: any;
+  objectType: string;
+}
+
+export const localStorageService = () => {
+  return {
+    get(itemName: string): any {
+      const item = localStorage.getItem(itemName);
+      if (item) {
+        const itemWrap: itemWrap = JSON.parse(item);
+
+        return itemWrap.objectType === 'string'
+          ? itemWrap.object
+          : JSON.parse(itemWrap.object);
+      } else {
+        throw new Error(`Element by key: '${itemName}' not found!`);
+      }
+    },
+
+    set(itemName: string, item: any): void {
+      localStorage.setItem(itemName, JSON.stringify(getItemWrap(item)));
+    },
+
+    remove(itemName: string): void {
+      localStorage.removeItem(itemName);
+    },
+  };
+};
+
+const getItemWrap = (item: any): itemWrap => {
+  const itemType = typeof item;
+  item = itemType === 'object' ? JSON.stringify(item) : item;
+  const itemWrap: itemWrap = {
+    object: item,
+    objectType: itemType,
+  };
+  return itemWrap;
+};

--- a/packages/client/src/service/store/storage.ts
+++ b/packages/client/src/service/store/storage.ts
@@ -1,4 +1,4 @@
-interface itemWrap {
+interface ItemWrap {
   object: any;
   objectType: string;
 }
@@ -8,7 +8,7 @@ export const localStorageService = () => {
     get(itemName: string): any {
       const item = localStorage.getItem(itemName);
       if (item) {
-        const itemWrap: itemWrap = JSON.parse(item);
+        const itemWrap: ItemWrap = JSON.parse(item);
 
         return itemWrap.objectType === 'string'
           ? itemWrap.object
@@ -28,10 +28,10 @@ export const localStorageService = () => {
   };
 };
 
-const getItemWrap = (item: any): itemWrap => {
+const getItemWrap = (item: any): ItemWrap => {
   const itemType = typeof item;
   item = itemType === 'object' ? JSON.stringify(item) : item;
-  const itemWrap: itemWrap = {
+  const itemWrap: ItemWrap = {
     object: item,
     objectType: itemType,
   };


### PR DESCRIPTION
Описание фичи можно прочитать в задаче:
https://linear.app/monopoly/issue/MON-70/dobavit-servis-storage

Обертка добавлена для случая, когда мы сохраняем данные аля
 localStorage.setItem('key', '123') и  localStorage.setItem('key', 123)
если не сохранить тип объекта, который пришел, мы получим строку '123' в этих обоих случаях и не понятно, что нужно вернуть при вызове localStorage.getItem('key'), '123' ил 123?